### PR TITLE
[fix] Index name was always "index" :trollface:

### DIFF
--- a/scripts/test
+++ b/scripts/test
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const fetch = require('node-fetch')
-const assert = require('assert')
+const assert = require('assert').strict
 const util = require('util')
 
 const data = {
@@ -15,7 +15,7 @@ const currentDate = new Date()
 const day = ('0' + currentDate.getDate()).slice(-2)
 const month = ('0' + (currentDate.getMonth() + 1)).slice(-2)
 const year = currentDate.getFullYear()
-const dailyIndex = `index-${year}.${month}.${day}`
+const dailyIndex = `${index}-${year}.${month}.${day}`
 let exit_code = 0
 
 fetch('http://127.0.0.1:3000/sns-receiver/sns-messages/', {
@@ -56,6 +56,7 @@ fetch('http://127.0.0.1:3000/sns-receiver/sns-messages/', {
                       }
                     )
                     assert.equal(es_res[0]._id, 'abcd')
+                    assert.ok(es_res[0]._index.match(/^sns-messages-[0-9]{4}\.[0-9]{2}\.[0-9]{2}$/))
                     // === End of main tests ====
                   } catch (err) {
                     console.log(err)

--- a/src/sns-receiver.js
+++ b/src/sns-receiver.js
@@ -11,7 +11,7 @@ router.post('/:index/:types?', function (req, res, next) {
   const day = ('0' + currentDate.getDate()).slice(-2)
   const month = ('0' + (currentDate.getMonth() + 1)).slice(-2)
   const year = currentDate.getFullYear()
-  const dailyIndex = `index-${year}.${month}.${day}`
+  const dailyIndex = `${index}-${year}.${month}.${day}`
   //  Override types for ES 6.3 where an index can only handle a single type value
   //  Leaving the ability to specify a type in the route in order to allow for mapping it in the future into another field.
   //  if (!types) {


### PR DESCRIPTION
## Description

The current code always insert into an index with `index` as name instead of variable extrapolation.